### PR TITLE
Nicer menu parsing, comments as descriptions, configurable color.

### DIFF
--- a/xmonad/.xmonad/showHintForKeymap.sh
+++ b/xmonad/.xmonad/showHintForKeymap.sh
@@ -1,24 +1,66 @@
 #!/bin/sh
+##########################################################
+## Look through ~/.xmonad/xmonad.hs for the given key submap
+## in EZ-Config format.
+## Parse each line for the keys, commands and trailing comments.
+## Use comments for the description when available.
+## format into columns to fit the screen width.
+## send to dzen2 along with font colors and font.
+##########################################################
 KEYMAP=$1
-FW=7
-LH=14
+# make FW bigger if the columns don't fit on your screen
+FW=350
+LH=24
 X=$2
 W=$4
+KEYCOLOR=$6
+CMDCOLOR=$7
+FONT=$8
 COLS=$(($W / $FW))
-INFO=$(cat ~/.xmonad/xmonad.hs \
-     | awk '/^'"$KEYMAP"'/,/^\s*\]$/' \
-     | grep '(".*",.*)$' \
-     | sed -r 's/^.*?[,\[] \("([^"]+)",(\s*)(.*)\)/^fg(purple)\1\2^fg(white)\3/' \
-     | column -c $COLS \
-     | expand \
-     | sed 's/^/    /' )
+
+INFO=$(awk -v cmdcolor=$CMDCOLOR -v keycolor=$KEYCOLOR -v cols=$COLS \
+           '/^'"$KEYMAP"'/,/^\s*\].*$/ {
+                if ($0 ~ /^ *--+/) next
+
+                # get the key entry and any following comment.
+                split($0, splitline, " --", seps)
+                comma_loc=index(splitline[1], "\",")
+                match(substr(splitline[1], 1, comma_loc-1), /^.*\"(.*)/, keys)
+                match(substr(splitline[1], comma_loc+2), /^ *(.*)\)/, command)
+
+                # remove any leading spaces from the comment
+                gsub(/^[ \t]/, "", splitline[2])
+
+                # skip any empty records.
+                if (length(command[1]) > 0){
+                    # if there is a comment use that for the description.
+                    if (length(splitline[2]) > 0) {
+                            desc=splitline[2]
+                        } else {
+                            desc=command[1]
+                    }
+                    key_hint[i++] = sprintf (" ^fg(%s)%14.14s ^fg(%s)%-30.30s", keycolor, keys[1], cmdcolor, desc)
+                }
+            }
+            END {
+                rows = int( ((i+1) / cols) +1)
+                for (j=0; j<=i;) {
+                    for (k=0; k < rows; k++) {
+                         row[k] = row[k] key_hint[j++]
+                    }
+                }
+                for (k=0; k <= rows; k++) {print row[k]}
+            }' \
+           ~/.xmonad/xmonad.hs)
+
+## echo "30\n22\n20\n15\n3\n" | awk '{print $1 " : " int( (($1+1) / 10) + 1)}'
 echo "$INFO"
 N_LINES=$(wc -l <<< "$INFO")
 Y=$(($3 + $5 - ($LH * ($N_LINES+3))))
 sleep 1
 # $KEYMAP ($2 , $3 , $4 , $5, $LH, $X, $Y, $W, $N_LINES, $COLS
-(echo "^fg(purple)$KEYMAP"
+(echo "^fg($KEYCOLOR)$KEYMAP"
  echo ""
  echo "$INFO"
  echo ""
- cat) | dzen2 -l $(($N_LINES+2)) -h $LH -x $X -y $Y -w $W -e onstart=uncollapse
+ cat) | dzen2 -l $(($N_LINES+2)) -fn "${FONT}" -h $LH -x $X -y $Y -w $W -e onstart=uncollapse

--- a/xmonad/.xmonad/showHintForKeymap.sh
+++ b/xmonad/.xmonad/showHintForKeymap.sh
@@ -1,44 +1,23 @@
 #!/bin/sh
 KEYMAP=$1
 FW=7
-LH=16
+LH=14
 X=$2
 W=$4
-KEYCOLOR=$6
-CMDCOLOR=$7
 COLS=$(($W / $FW))
-
-INFO=$(awk -v cmdcolor=$CMDCOLOR -v keycolor=$KEYCOLOR \
-           '/^'"$KEYMAP"'/,/^\s*\]$/ {
-                # get the key entry and any following comment.
-                split($0, fields, "--", seps)
-                match($fields[1], /^.*\(\"(.*)\", *(.+)\).*/, cmd)
-
-                # remove any leading spaces
-                gsub(/^[ \t]/, "", cmd[2])
-                gsub(/^[ \t]/, "", fields[2])
-
-                # skip any empty records.
-                if (length(cmd[1]) > 0){
-                    # if there is a comment use that for the description.
-                    if (length(fields[2]) > 0) {
-                            desc=fields[2]
-                        } else {
-                            desc=cmd[2]
-                    }
-                    printf ("    ^fg(%s)%6s ^fg(%s)%s\n", keycolor, cmd[1], cmdcolor, desc)
-                }
-            }' \
-           ~/.xmonad/xmonad.hs \
-              | column -c $COLS \
-              | expand)
-
+INFO=$(cat ~/.xmonad/xmonad.hs \
+     | awk '/^'"$KEYMAP"'/,/^\s*\]$/' \
+     | grep '(".*",.*)$' \
+     | sed -r 's/^.*?[,\[] \("([^"]+)",(\s*)(.*)\)/^fg(purple)\1\2^fg(white)\3/' \
+     | column -c $COLS \
+     | expand \
+     | sed 's/^/    /' )
 echo "$INFO"
 N_LINES=$(wc -l <<< "$INFO")
 Y=$(($3 + $5 - ($LH * ($N_LINES+3))))
 sleep 1
 # $KEYMAP ($2 , $3 , $4 , $5, $LH, $X, $Y, $W, $N_LINES, $COLS
-(echo "^fg($KEYCOLOR)$KEYMAP"
+(echo "^fg(purple)$KEYMAP"
  echo ""
  echo "$INFO"
  echo ""

--- a/xmonad/.xmonad/showHintForKeymap.sh
+++ b/xmonad/.xmonad/showHintForKeymap.sh
@@ -1,23 +1,44 @@
 #!/bin/sh
 KEYMAP=$1
 FW=7
-LH=14
+LH=16
 X=$2
 W=$4
+KEYCOLOR=$6
+CMDCOLOR=$7
 COLS=$(($W / $FW))
-INFO=$(cat ~/.xmonad/xmonad.hs \
-     | awk '/^'"$KEYMAP"'/,/^\s*\]$/' \
-     | grep '(".*",.*)$' \
-     | sed -r 's/^.*?[,\[] \("([^"]+)",(\s*)(.*)\)/^fg(purple)\1\2^fg(white)\3/' \
-     | column -c $COLS \
-     | expand \
-     | sed 's/^/    /' )
+
+INFO=$(awk -v cmdcolor=$CMDCOLOR -v keycolor=$KEYCOLOR \
+           '/^'"$KEYMAP"'/,/^\s*\]$/ {
+                # get the key entry and any following comment.
+                split($0, fields, "--", seps)
+                match($fields[1], /^.*\(\"(.*)\", *(.+)\).*/, cmd)
+
+                # remove any leading spaces
+                gsub(/^[ \t]/, "", cmd[2])
+                gsub(/^[ \t]/, "", fields[2])
+
+                # skip any empty records.
+                if (length(cmd[1]) > 0){
+                    # if there is a comment use that for the description.
+                    if (length(f[2]) > 0) {
+                            desc=fields[2]
+                        } else {
+                            desc=cmd[2]
+                    }
+                    printf ("    ^fg(%s)%6s ^fg(%s)%s\n", keycolor, cmd[1], cmdcolor, desc)
+                }
+            }' \
+                ~/.xmonad/xmonad.hs \
+                   | column -c $COLS \
+                   | expand)
+
 echo "$INFO"
 N_LINES=$(wc -l <<< "$INFO")
 Y=$(($3 + $5 - ($LH * ($N_LINES+3))))
 sleep 1
 # $KEYMAP ($2 , $3 , $4 , $5, $LH, $X, $Y, $W, $N_LINES, $COLS
-(echo "^fg(purple)$KEYMAP"
+(echo "^fg($KEYCOLOR)$KEYMAP"
  echo ""
  echo "$INFO"
  echo ""

--- a/xmonad/.xmonad/showHintForKeymap.sh
+++ b/xmonad/.xmonad/showHintForKeymap.sh
@@ -21,7 +21,7 @@ INFO=$(awk -v cmdcolor=$CMDCOLOR -v keycolor=$KEYCOLOR \
                 # skip any empty records.
                 if (length(cmd[1]) > 0){
                     # if there is a comment use that for the description.
-                    if (length(f[2]) > 0) {
+                    if (length(fields[2]) > 0) {
                             desc=fields[2]
                         } else {
                             desc=cmd[2]
@@ -29,9 +29,9 @@ INFO=$(awk -v cmdcolor=$CMDCOLOR -v keycolor=$KEYCOLOR \
                     printf ("    ^fg(%s)%6s ^fg(%s)%s\n", keycolor, cmd[1], cmdcolor, desc)
                 }
             }' \
-                ~/.xmonad/xmonad.hs \
-                   | column -c $COLS \
-                   | expand)
+           ~/.xmonad/xmonad.hs \
+              | column -c $COLS \
+              | expand)
 
 echo "$INFO"
 N_LINES=$(wc -l <<< "$INFO")

--- a/xmonad/.xmonad/xmonad.hs
+++ b/xmonad/.xmonad/xmonad.hs
@@ -90,10 +90,20 @@ focusedScreenSize = withWindowSet $ windowScreenSize . fromJust . W.peek
   -- ss <- windowScreenSize $ fromJust $ W.peek ws
   -- return ss
 
+keyColor = "purple"
+cmdColor = "white"
+
 keyMapDoc :: String -> X Handle
 keyMapDoc name = do
   ss <- focusedScreenSize
-  handle <- spawnPipe $ unwords ["~/.xmonad/showHintForKeymap.sh", name, show (rect_x ss), show (rect_y ss), show (rect_width ss), show (rect_height ss)]
+  handle <- spawnPipe $ unwords ["~/.xmonad/showHintForKeymap.sh",
+                                 name,
+                                 show (rect_x ss),
+                                 show (rect_y ss),
+                                 show (rect_width ss),
+                                 show (rect_height ss)
+                                 keyColor,
+                                 cmdColor]
   return handle
 
 toSubmap :: XConfig l -> String -> [(String, X ())] -> X ()

--- a/xmonad/.xmonad/xmonad.hs
+++ b/xmonad/.xmonad/xmonad.hs
@@ -92,6 +92,8 @@ focusedScreenSize = withWindowSet $ windowScreenSize . fromJust . W.peek
 
 keyColor = "purple"
 cmdColor = "white"
+-- double quoted so it can make it all the way to dzen.
+dzenFont = "\"-*-ubuntu mono-*-*-*-*-*-*-*-*-*-*-*-*\""
 
 keyMapDoc :: String -> X Handle
 keyMapDoc name = do
@@ -103,7 +105,8 @@ keyMapDoc name = do
                                  show (rect_width ss),
                                  show (rect_height ss)
                                  keyColor,
-                                 cmdColor]
+                                 cmdColor,
+                                 dzenFont]
   return handle
 
 toSubmap :: XConfig l -> String -> [(String, X ())] -> X ()


### PR DESCRIPTION
Hi, Thanks for this.  It's really nice.  I fixed up the menu parsing with awk.  It's much more tolerant of the formatting now.  I tried to get it to work as a separate awk program, but couldn't figure out how to do a range pattern with a variable substitute.   if (0 ~ foo) works for simple stuff, but not range patterns.  Breaking it into two awk steps worked from the commandline but not from xmonad. weird. 

I've tried numerous bad formatting and the parsing seems to work fine.  It also looks for comments at the end of the line and uses those as the action descriptor if it finds them.  Additionally the key color and command color can be set in xmonad.hs and passed to the script.

I changed the line height to 16.  Everything was smashed together in my setup. I'm not sure why. I don't have any xresources set for dzen2.  I suppose that could be passed in as well.